### PR TITLE
#2972944 Admin routes not working when site is in a subfolder

### DIFF
--- a/domain_site_settings/domain_site_settings.routing.yml
+++ b/domain_site_settings/domain_site_settings.routing.yml
@@ -1,5 +1,5 @@
 domain_site_settings.list:
-  path: '/admin/config/domain/domain_site_settings'
+  path: 'admin/config/domain/domain_site_settings'
   defaults:
     _controller: '\Drupal\domain_site_settings\Controller\DomainSiteSettingsController::domainList'
     _title: 'Domains sites list'
@@ -8,7 +8,7 @@ domain_site_settings.list:
   options:
     _admin_route: TRUE
 domain_site_settings.config_form:
-  path: '/admin/config/domain/domain_site_settings/{domain_id}/edit'
+  path: 'admin/config/domain/domain_site_settings/{domain_id}/edit'
   defaults:
     _form: '\Drupal\domain_site_settings\Form\DomainConfigSettingsForm'
     _title: 'Domain site settings'


### PR DESCRIPTION
PATCH from "#2972944 Admin routes not working when site is installed in a subfolder": https://www.drupal.org/project/domain_site_settings/issues/2972944